### PR TITLE
Fix linux build

### DIFF
--- a/cimgui.cpp
+++ b/cimgui.cpp
@@ -2943,7 +2943,7 @@ CIMGUI_API ImGuiID igImHashStr(const char* data,size_t data_size,ImGuiID seed)
 {
     return ImHashStr(data,data_size,seed);
 }
-CIMGUI_API void igImQsort(void* base,size_t count,size_t size_of_element,int(__cdecl*compare_func)(void const*,void const*))
+CIMGUI_API void igImQsort(void* base,size_t count,size_t size_of_element,int(CIMGUI_CDECL *compare_func)(void const*,void const*))
 {
     return ImQsort(base,count,size_of_element,compare_func);
 }

--- a/cimgui.h
+++ b/cimgui.h
@@ -35,8 +35,10 @@
 
 #ifdef _MSC_VER
 typedef unsigned __int64 ImU64;
+#define CIMGUI_CDECL __cdecl
 #else
 //typedef unsigned long long ImU64;
+#define CIMGUI_CDECL
 #endif
 
 
@@ -4658,7 +4660,7 @@ CIMGUI_API ImGuiPlatformImeData* ImGuiPlatformImeData_ImGuiPlatformImeData(void)
 CIMGUI_API void ImGuiPlatformImeData_destroy(ImGuiPlatformImeData* self);
 CIMGUI_API ImGuiID igImHashData(const void* data,size_t data_size,ImGuiID seed);
 CIMGUI_API ImGuiID igImHashStr(const char* data,size_t data_size,ImGuiID seed);
-CIMGUI_API void igImQsort(void* base,size_t count,size_t size_of_element,int(__cdecl*compare_func)(void const*,void const*));
+CIMGUI_API void igImQsort(void* base,size_t count,size_t size_of_element,int(CIMGUI_CDECL *compare_func)(void const*,void const*));
 CIMGUI_API ImU32 igImAlphaBlendColors(ImU32 col_a,ImU32 col_b);
 CIMGUI_API bool igImIsPowerOfTwo_Int(int v);
 CIMGUI_API bool igImIsPowerOfTwo_U64(ImU64 v);


### PR DESCRIPTION
This fixes the failed builds for Linux (See [this i2d-ingui issue](https://github.com/Inochi2D/i2d-imgui/issues/33)).

The __cdecl macro seems to be a Windows macro, so i copied the solution found in the [imgui/imgui_demo.cpp](https://github.com/ocornut/imgui/blob/64aab8480a5643cec1880af17931963a90a8f990/imgui_demo.cpp#L156).

The Windows build has yet to be tested.